### PR TITLE
build: upgrade connector and JDBC driver versions

### DIFF
--- a/Makefile.param
+++ b/Makefile.param
@@ -18,7 +18,7 @@ ORACLE_PDB ?= XEPDB1
 
 # Kafka Connect image
 KAFKA_CONNECT_IMAGE ?= kafka-dbsync/cp-kafka-connect-debezium
-KAFKA_CONNECT_IMAGE_TAG ?= 3.4.0
+KAFKA_CONNECT_IMAGE_TAG ?= 3.4.1
 
 # Kafka Connect service
 KAFKA_CONNECT_SVC ?= dbrep-kafka-connect-v3-cp-kafka-connect

--- a/deployment/kafka-connect/docker/Dockerfile.debezium
+++ b/deployment/kafka-connect/docker/Dockerfile.debezium
@@ -46,41 +46,41 @@ FROM confluentinc/cp-kafka-connect:7.8.0
 USER root
 
 ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
-RUN confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.6.4
+RUN confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.9.2
 RUN confluent-hub install --no-prompt confluentinc/kafka-connect-s3:10.6.7
 RUN confluent-hub install --no-prompt confluentinc/connect-transforms:1.4.6
-RUN confluent-hub install --no-prompt mongodb/kafka-connect-mongodb:2.0.0
+RUN confluent-hub install --no-prompt mongodb/kafka-connect-mongodb:2.0.3
 
 # Install debezium for Oracle
-RUN wget https://repo1.maven.org/maven2/io/debezium/debezium-connector-oracle/3.4.0.Final/debezium-connector-oracle-3.4.0.Final-plugin.tar.gz
-RUN tar zxvf debezium-connector-oracle-3.4.0.Final-plugin.tar.gz -C /usr/share/java/
+RUN wget https://repo1.maven.org/maven2/io/debezium/debezium-connector-oracle/3.4.1.Final/debezium-connector-oracle-3.4.1.Final-plugin.tar.gz
+RUN tar zxvf debezium-connector-oracle-3.4.1.Final-plugin.tar.gz -C /usr/share/java/
 RUN wget https://repo1.maven.org/maven2/com/oracle/database/xml/xdb/21.11.0.0/xdb-21.11.0.0.jar -P /usr/share/java/debezium-connector-oracle/
 # Install debezium for MySQL
-RUN wget https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/3.4.0.Final/debezium-connector-mysql-3.4.0.Final-plugin.tar.gz
-RUN tar zxvf debezium-connector-mysql-3.4.0.Final-plugin.tar.gz -C /usr/share/java/
+RUN wget https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/3.4.1.Final/debezium-connector-mysql-3.4.1.Final-plugin.tar.gz
+RUN tar zxvf debezium-connector-mysql-3.4.1.Final-plugin.tar.gz -C /usr/share/java/
 # Install debezium for SQLServer
-RUN wget https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/3.4.0.Final/debezium-connector-sqlserver-3.4.0.Final-plugin.tar.gz
-RUN tar zxvf debezium-connector-sqlserver-3.4.0.Final-plugin.tar.gz -C /usr/share/java/
+RUN wget https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/3.4.1.Final/debezium-connector-sqlserver-3.4.1.Final-plugin.tar.gz
+RUN tar zxvf debezium-connector-sqlserver-3.4.1.Final-plugin.tar.gz -C /usr/share/java/
 # Install debezium for MongoDB
-RUN wget https://repo1.maven.org/maven2/io/debezium/debezium-connector-mongodb/3.4.0.Final/debezium-connector-mongodb-3.4.0.Final-plugin.tar.gz
-RUN tar zxvf debezium-connector-mongodb-3.4.0.Final-plugin.tar.gz -C /usr/share/java/
+RUN wget https://repo1.maven.org/maven2/io/debezium/debezium-connector-mongodb/3.4.1.Final/debezium-connector-mongodb-3.4.1.Final-plugin.tar.gz
+RUN tar zxvf debezium-connector-mongodb-3.4.1.Final-plugin.tar.gz -C /usr/share/java/
 
 # Install debezium for JDBC Sink
-RUN wget https://repo1.maven.org/maven2/io/debezium/debezium-connector-jdbc/3.4.0.Final/debezium-connector-jdbc-3.4.0.Final-plugin.tar.gz
-RUN tar zxvf debezium-connector-jdbc-3.4.0.Final-plugin.tar.gz -C /usr/share/java/
+RUN wget https://repo1.maven.org/maven2/io/debezium/debezium-connector-jdbc/3.4.1.Final/debezium-connector-jdbc-3.4.1.Final-plugin.tar.gz
+RUN tar zxvf debezium-connector-jdbc-3.4.1.Final-plugin.tar.gz -C /usr/share/java/
 
 # Must put the mysql, mariadb, clickhouse, sqlserver driver into jdbc folder
 ## mysql
 RUN wget https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-j-8.0.32.tar.gz
 RUN tar zxvf mysql-connector-j-8.0.32.tar.gz -C /usr/share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib
 ## mariadb
-RUN wget https://dlm.mariadb.com/2720710/Connectors/java/connector-java-3.1.2/mariadb-java-client-3.1.2.jar -P /usr/share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib/
+RUN wget https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/3.5.7/mariadb-java-client-3.5.7.jar -P /usr/share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib/
 ## clickhouse
 RUN wget https://github.com/ClickHouse/clickhouse-java/releases/download/v0.4.6/clickhouse-jdbc-0.4.6.jar -P /usr/share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib/
 ## sqlserver
-RUN wget --no-check-certificate https://download.microsoft.com/download/9/e/9/9e97cef4-4c64-484c-bd1b-192147912c47/enu/sqljdbc_12.6.1.0_enu.tar.gz
-RUN tar zxvf sqljdbc_12.6.1.0_enu.tar.gz -C /usr/share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib
-RUN mv /usr/share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib/sqljdbc_12.6/enu/jars/* /usr/share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib/
+RUN wget --no-check-certificate https://download.microsoft.com/download/aef8c909-5763-4b89-84e5-851b59eb082b/sqljdbc_12.10.2.0_enu.tar.gz
+RUN tar zxvf sqljdbc_12.10.2.0_enu.tar.gz -C /usr/share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib
+RUN mv /usr/share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib/sqljdbc_12.10/enu/jars/* /usr/share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib/
 
 # Install JMX agent
 # ref: https://github.com/debezium/debezium-examples/blob/main/monitoring/debezium-jmx-exporter/Dockerfile

--- a/deployment/kafka-connect/docker/sink/IidrCdcSinkConnector/pom.xml
+++ b/deployment/kafka-connect/docker/sink/IidrCdcSinkConnector/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>12.4.2.jre11</version>
+            <version>12.10.2.jre11</version>
         </dependency>
         <!-- Oracle -->
         <dependency>


### PR DESCRIPTION
- Debezium 3.4.0 → 3.4.1
- Confluent JDBC 10.6.4 → 10.9.2
- MongoDB connector 2.0.0 → 2.0.3
- MariaDB JDBC 3.1.2 → 3.5.7
- SQL Server JDBC 12.6.1 → 12.10.2