### PR TITLE
fix: use patched redpanda-console image for Debezium 3.5.x compat

### DIFF
--- a/deployment/redpanda-console/values.yaml
+++ b/deployment/redpanda-console/values.yaml
@@ -2,8 +2,8 @@ redpanda-console:
   replicaCount: 1
 
   image:
-    repository: redpandadata/console
-    tag: v3.7.3
+    repository: isliao613/redpanda-console
+    tag: v3.7.4-patched
     pullPolicy: IfNotPresent
 
   nameOverride: ""


### PR DESCRIPTION
Debezium Oracle 3.5.x returns null value sections for deprecated XStream properties, crashing the connector detail page. Switch to a locally patched build until the upstream fix lands in a release.