### PR TITLE
feat: add MongoDB Debezium source and sink with E2E test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ help:
 	@echo "  make -f Makefile.e2e help       # E2E testing"
 	@echo "  make -f Makefile.datatype help  # Datatype testing"
 	@echo "  make -f Makefile.iidr help      # IIDR CDC sink testing"
+	@echo "  make -f Makefile.mongo-e2e help # MongoDB E2E testing"
 	@echo ""
 	@echo "=== Infrastructure (Makefile.common) ==="
 	@echo "  base-infra-up        - Create Kind cluster and deploy base services"
@@ -42,6 +43,7 @@ help:
 	@echo "  setup-oracle         - Set up Oracle XE 21c for CDC"
 	@echo "  setup-mariadb        - Set up MariaDB target database"
 	@echo "  setup-postgres       - Set up PostgreSQL target database"
+	@echo "  setup-mongodb        - Verify MongoDB connectivity"
 	@echo "  logs                 - View Kafka Connect logs"
 	@echo "  status               - Check connector status"
 	@echo "  port-forward         - Set up port forwarding"
@@ -83,6 +85,13 @@ help:
 	@echo "  mariadb-e2e-verify   - Verify data in PostgreSQL"
 	@echo "  mariadb-e2e-clean    - Clean up MariaDB connectors and tables"
 	@echo ""
+	@echo "=== MongoDB E2E Testing (Makefile.mongo-e2e) ==="
+	@echo "  mongo-e2e-all        - Full MongoDB E2E pipeline"
+	@echo "  mongo-e2e-setup      - Set up MongoDB source and target collections"
+	@echo "  mongo-e2e-run        - Run MongoDB CDC tests"
+	@echo "  mongo-e2e-verify     - Verify data in MongoDB target collection"
+	@echo "  mongo-e2e-clean      - Clean up MongoDB connectors and collections"
+	@echo ""
 	@echo "Kafka Connect Service:"
 	@echo "  Debezium: $(KAFKA_CONNECT_SVC):8083"
 
@@ -90,7 +99,7 @@ help:
 # Infrastructure (Makefile.common)
 # =============================================================================
 
-.PHONY: base-infra-up clean .tools .check-tools setup-oracle setup-mariadb setup-postgres \
+.PHONY: base-infra-up clean .tools .check-tools setup-oracle setup-mariadb setup-postgres setup-mongodb \
 	logs status port-forward
 
 base-infra-up:
@@ -113,6 +122,9 @@ setup-mariadb:
 
 setup-postgres:
 	@$(MAKE) -f Makefile.common setup-postgres
+
+setup-mongodb:
+	@$(MAKE) -f Makefile.common setup-mongodb
 
 logs:
 	@$(MAKE) -f Makefile.common logs
@@ -239,3 +251,24 @@ mariadb-e2e-verify:
 
 mariadb-e2e-clean:
 	@$(MAKE) -f Makefile.mariadb-e2e test-clean
+
+# =============================================================================
+# MongoDB E2E Testing (Makefile.mongo-e2e)
+# =============================================================================
+
+.PHONY: mongo-e2e-all mongo-e2e-setup mongo-e2e-run mongo-e2e-verify mongo-e2e-clean
+
+mongo-e2e-all:
+	@$(MAKE) -f Makefile.mongo-e2e all
+
+mongo-e2e-setup:
+	@$(MAKE) -f Makefile.mongo-e2e test-setup
+
+mongo-e2e-run:
+	@$(MAKE) -f Makefile.mongo-e2e test-run
+
+mongo-e2e-verify:
+	@$(MAKE) -f Makefile.mongo-e2e test-verify
+
+mongo-e2e-clean:
+	@$(MAKE) -f Makefile.mongo-e2e test-clean

--- a/Makefile.common
+++ b/Makefile.common
@@ -14,7 +14,7 @@ include Makefile.param
 # =============================================================================
 
 .PHONY: help base-infra-up clean .check-tools .tools \
-	setup-oracle setup-mariadb setup-postgres \
+	setup-oracle setup-mariadb setup-postgres setup-mongodb \
 	logs status port-forward
 
 # =============================================================================
@@ -34,6 +34,7 @@ help:
 	@echo "  setup-oracle         - Set up Oracle XE 21c for CDC"
 	@echo "  setup-mariadb        - Set up MariaDB target database"
 	@echo "  setup-postgres       - Set up PostgreSQL target database"
+	@echo "  setup-mongodb        - Verify MongoDB connectivity"
 	@echo ""
 	@echo "Utilities:"
 	@echo "  logs                 - View logs of Kafka Connect"
@@ -77,6 +78,7 @@ base-infra-up: .check-tools
 	kubectl apply -f helm-chart/minio/minio-dev.yaml -n $(NAMESPACE)
 	helm dependency build deployment/mssql
 	helm upgrade --install dbrep-mssql deployment/mssql -f deployment/mssql/values.yaml -n $(NAMESPACE)
+	kubectl apply -f deployment/mongodb/mongodb.yaml -n $(NAMESPACE)
 	@echo "[INFO] Deploying Oracle XE 21c..."
 	kubectl apply -f deployment/oracle/oracle-free.yaml -n $(NAMESPACE)
 	helm dependency build deployment/curl-client
@@ -86,6 +88,7 @@ base-infra-up: .check-tools
 	kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=kafka --timeout=300s -n $(NAMESPACE)
 	kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=mariadb --timeout=300s -n $(NAMESPACE)
 	kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=postgresql --timeout=300s -n $(NAMESPACE)
+	kubectl wait --for=condition=ready pod -l app=mongodb --timeout=300s -n $(NAMESPACE)
 	kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=curl-client --timeout=120s -n $(NAMESPACE)
 	kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=akhq --timeout=120s -n $(NAMESPACE)
 	kubectl wait --for=condition=ready pod -l app=oracle-db --timeout=300s -n $(NAMESPACE)
@@ -98,6 +101,8 @@ clean:
 	sleep 10
 	-kubectl delete -f deployment/oracle/oracle-free.yaml -n $(NAMESPACE) || true
 	-helm uninstall dbrep-mssql -n $(NAMESPACE) || true
+	-kubectl delete -f deployment/mongodb/mongodb.yaml -n $(NAMESPACE) || true
+	-kubectl delete pvc -l app=mongodb -n $(NAMESPACE) || true
 	-kubectl delete -f helm-chart/minio/minio-dev.yaml -n $(NAMESPACE) || true
 	-helm uninstall dbrep-mariadb -n $(NAMESPACE) || true
 	-helm uninstall dbrep-postgres -n $(NAMESPACE) || true
@@ -179,6 +184,11 @@ setup-postgres:
 	kubectl exec $(POSTGRES_POD) -n $(NAMESPACE) -- env PGPASSWORD=$(POSTGRES_PASS) psql -U $(POSTGRES_USER) -d $(POSTGRES_DB) -c \
 		"DROP TABLE IF EXISTS target_orders;"
 	@echo "[OK] PostgreSQL setup completed"
+
+setup-mongodb:
+	@echo "[INFO] Verifying MongoDB connectivity..."
+	kubectl exec $(MONGO_POD) -n $(NAMESPACE) -- mongosh --quiet --eval 'db.adminCommand({ping:1})'
+	@echo "[OK] MongoDB is ready"
 
 # =============================================================================
 # Utilities

--- a/Makefile.mongo-e2e
+++ b/Makefile.mongo-e2e
@@ -1,0 +1,155 @@
+# Makefile.mongo-e2e
+#
+# End-to-end testing for MongoDB CDC replication.
+# Source: MongoDB source_database.source_orders (Debezium MongoDB connector)
+# Sink:   MongoDB target_database.target_orders (MongoDB Kafka sink connector)
+#
+# Can be run independently: make -f Makefile.mongo-e2e <target>
+#
+# Prerequisites:
+#   - Infrastructure deployed (make -f Makefile.common base-infra-up)
+#   - Kafka Connect image built (make -f Makefile.docker build)
+#
+# ==============================================================================
+
+.DEFAULT_GOAL := help
+
+include Makefile.param
+
+MONGOSH = kubectl exec $(MONGO_POD) -n $(NAMESPACE) -- mongosh --quiet
+KAFKA_EXEC = kubectl exec $(KAFKA_POD) -n $(NAMESPACE) -- /opt/bitnami/kafka/bin/kafka-topics.sh \
+	--bootstrap-server localhost:9092
+
+# =============================================================================
+# Phony Targets
+# =============================================================================
+
+.PHONY: help all \
+	test test-setup test-run test-verify test-clean \
+	setup-source setup-target \
+	register verify
+
+# =============================================================================
+# Help
+# =============================================================================
+
+help:
+	@echo "Usage: make -f Makefile.mongo-e2e [target]"
+	@echo ""
+	@echo "Full Workflows:"
+	@echo "  all                  - Full E2E pipeline"
+	@echo ""
+	@echo "Testing:"
+	@echo "  test                 - Run full test cycle (setup, run, verify, clean)"
+	@echo "  test-setup           - Set up MongoDB source and target collections"
+	@echo "  test-run             - Run CDC tests (insert, update, delete)"
+	@echo "  test-verify          - Verify data in target collection"
+	@echo "  test-clean           - Clean up connectors and collections"
+	@echo ""
+	@echo "Collection Setup:"
+	@echo "  setup-source         - Insert initial documents into MongoDB source"
+	@echo "  setup-target         - Drop target collection for a clean test"
+	@echo ""
+	@echo "Connector Management:"
+	@echo "  register             - Register MongoDB source and sink connectors"
+	@echo "  verify               - Verify data in target collection"
+
+# =============================================================================
+# Full Workflows
+# =============================================================================
+
+all: setup-source setup-target register test-run verify
+	@echo "[OK] MongoDB E2E pipeline completed!"
+
+# =============================================================================
+# Collection Setup
+# =============================================================================
+
+setup-source:
+	@echo "[INFO] Setting up MongoDB source collection..."
+	$(MONGOSH) --eval \
+		'db.getSiblingDB("source_database").source_orders.drop(); db.getSiblingDB("source_database").source_orders.insertMany([{_id:1,order_no:"ORD-001",customer_name:"Alice",amount:1000,status:"PENDING"},{_id:2,order_no:"ORD-002",customer_name:"Bob",amount:2000,status:"PROCESSING"},{_id:3,order_no:"ORD-003",customer_name:"Charlie",amount:1500,status:"COMPLETED"},{_id:4,order_no:"ORD-004",customer_name:"Diana",amount:500,status:"PENDING"}]); print("Inserted " + db.getSiblingDB("source_database").source_orders.countDocuments() + " documents")'
+	@echo "[OK] MongoDB source setup completed"
+
+setup-target:
+	@echo "[INFO] Dropping target collection and CDC topic for clean test..."
+	$(MONGOSH) --eval 'db.getSiblingDB("target_database").target_orders.drop(); print("Target collection dropped")'
+	-$(KAFKA_EXEC) --delete --topic cdc_mongodb.source_database.source_orders 2>/dev/null || true
+	@echo "[OK] Target collection and topic cleared"
+
+# =============================================================================
+# Connector Registration
+# =============================================================================
+
+register:
+	@echo "[INFO] Registering connectors on $(KAFKA_CONNECT_SVC)..."
+	@echo "[INFO] Waiting for Kafka Connect API to be ready..."
+	@for i in $$(seq 1 30); do \
+		if kubectl exec $(CURL_POD) -n $(NAMESPACE) -- curl -sf http://$(KAFKA_CONNECT_SVC):8083/connectors >/dev/null; then \
+			echo "[OK] Kafka Connect API is ready"; \
+			break; \
+		fi; \
+		echo "...waiting ($$i/30)"; \
+		sleep 5; \
+	done
+	kubectl cp hack/source-debezium/mongodb-source.json $(CURL_POD):/tmp/mongodb-source.json -n $(NAMESPACE)
+	kubectl exec $(CURL_POD) -n $(NAMESPACE) -- curl -sf --max-time 10 -X POST \
+		http://$(KAFKA_CONNECT_SVC):8083/connectors \
+		-H "Content-Type: application/json" \
+		-d @/tmp/mongodb-source.json || echo "[ERROR] Failed to register source connector"
+	@echo "[INFO] Waiting 20s for initial snapshot..."
+	@sleep 20
+	kubectl cp hack/sink-mongodb/mongodb-sink.json $(CURL_POD):/tmp/mongodb-sink.json -n $(NAMESPACE)
+	kubectl exec $(CURL_POD) -n $(NAMESPACE) -- curl -sf --max-time 10 -X POST \
+		http://$(KAFKA_CONNECT_SVC):8083/connectors \
+		-H "Content-Type: application/json" \
+		-d @/tmp/mongodb-sink.json || echo "[ERROR] Failed to register sink connector"
+	@echo "[INFO] Waiting 10s for sync..."
+	@sleep 10
+	@echo "[OK] Connectors registered"
+
+# =============================================================================
+# Verification
+# =============================================================================
+
+verify:
+	@echo "[INFO] Data in MongoDB target_database.target_orders:"
+	$(MONGOSH) --eval 'db.getSiblingDB("target_database").target_orders.find().sort({_id:1}).forEach(d => print(EJSON.stringify(d)))' 2>/dev/null || echo "Collection not found or empty"
+
+# =============================================================================
+# Testing
+# =============================================================================
+
+test: test-setup test-run test-verify test-clean
+
+test-setup: setup-source setup-target
+
+test-run:
+	@echo "[INFO] Running CDC tests..."
+	@echo "[INFO] Testing INSERT..."
+	$(MONGOSH) --eval \
+		'db.getSiblingDB("source_database").source_orders.insertOne({_id:5,order_no:"ORD-005",customer_name:"Eve",amount:3100,status:"PENDING"})'
+	@echo "[INFO] Waiting 5s for replication..." && sleep 5
+	@echo "[INFO] Testing UPDATE..."
+	$(MONGOSH) --eval \
+		'db.getSiblingDB("source_database").source_orders.updateOne({_id:1},{$$set:{status:"COMPLETED"}})'
+	@echo "[INFO] Waiting 5s for replication..." && sleep 5
+	@echo "[INFO] Testing DELETE..."
+	$(MONGOSH) --eval \
+		'db.getSiblingDB("source_database").source_orders.deleteOne({_id:3})'
+	@echo "[INFO] Waiting 5s for replication..." && sleep 5
+
+test-verify: verify
+
+test-clean:
+	@echo "[INFO] Deleting connectors..."
+	-kubectl exec $(CURL_POD) -n $(NAMESPACE) -- curl -s -X DELETE \
+		http://$(KAFKA_CONNECT_SVC):8083/connectors/source_cdc_mongodb_demo
+	-kubectl exec $(CURL_POD) -n $(NAMESPACE) -- curl -s -X DELETE \
+		http://$(KAFKA_CONNECT_SVC):8083/connectors/sink_cdc_mongodb_to_mongodb
+	@echo "[OK] Connectors deleted"
+	@echo "[INFO] Dropping MongoDB source and target collections..."
+	$(MONGOSH) --eval \
+		'db.getSiblingDB("source_database").source_orders.drop(); db.getSiblingDB("target_database").target_orders.drop(); print("Collections dropped")'
+	-$(KAFKA_EXEC) --delete --topic cdc_mongodb.source_database.source_orders 2>/dev/null || true
+	@echo "[OK] Reset completed"

--- a/Makefile.param
+++ b/Makefile.param
@@ -36,6 +36,11 @@ POSTGRES_USER ?= postgres
 POSTGRES_PASS ?= postgres_password
 POSTGRES_DB ?= target_database
 
+# MongoDB configuration
+MONGO_POD ?= dbrep-mongodb-0
+MONGO_USER ?= root
+MONGO_PASS ?= root_password
+
 # Internal helpers
 CURL_POD = $(shell kubectl get pod -l app.kubernetes.io/name=curl-client -n $(NAMESPACE) -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
 ORACLE_POD = $(shell kubectl get pods -n $(NAMESPACE) -l app=oracle-db -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)

--- a/deployment/mongodb/mongodb.yaml
+++ b/deployment/mongodb/mongodb.yaml
@@ -1,0 +1,98 @@
+# MongoDB single-node replica set for CDC (change streams require replica set)
+# Uses official mongo:7.0 image. No auth — dev/test environment only.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: dbrep-mongodb-headless
+  labels:
+    app: mongodb
+spec:
+  clusterIP: None
+  selector:
+    app: mongodb
+  ports:
+    - name: mongodb
+      port: 27017
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dbrep-mongodb
+  labels:
+    app: mongodb
+spec:
+  selector:
+    app: mongodb
+  ports:
+    - name: mongodb
+      port: 27017
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dbrep-mongodb
+spec:
+  serviceName: dbrep-mongodb-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mongodb
+  template:
+    metadata:
+      labels:
+        app: mongodb
+    spec:
+      containers:
+        - name: mongodb
+          image: mongo:7.0
+          args:
+            - "--replSet"
+            - "rs0"
+            - "--bind_ip_all"
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - bash
+                  - -c
+                  - |
+                    for i in $(seq 1 30); do
+                      mongosh --quiet --eval "db.adminCommand({ping:1})" >/dev/null 2>&1 && break
+                      sleep 2
+                    done
+                    mongosh --quiet --eval "try { rs.initiate({_id:'rs0',members:[{_id:0,host:'dbrep-mongodb-0.dbrep-mongodb-headless.dev.svc.cluster.local:27017'}]}) } catch(e) {}" >/dev/null 2>&1 || true
+          readinessProbe:
+            exec:
+              command:
+                - mongosh
+                - --quiet
+                - --eval
+                - "db.adminCommand({ping:1})"
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          ports:
+            - containerPort: 27017
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 100m
+            limits:
+              memory: 512Mi
+              cpu: 500m
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/hack/sink-mongodb/mongodb-sink.json
+++ b/hack/sink-mongodb/mongodb-sink.json
@@ -1,0 +1,22 @@
+{
+    "name": "sink_cdc_mongodb_to_mongodb",
+    "config": {
+        "connector.class": "com.mongodb.kafka.connect.MongoSinkConnector",
+        "tasks.max": "1",
+        "topics": "cdc_mongodb.source_database.source_orders",
+        "connection.uri": "mongodb://dbrep-mongodb-0.dbrep-mongodb-headless.dev.svc.cluster.local:27017/?directConnection=true",
+        "database": "target_database",
+        "collection": "target_orders",
+        "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "key.converter.schemas.enable": "false",
+        "value.converter.schemas.enable": "false",
+        "document.id.strategy": "com.mongodb.kafka.connect.sink.processor.id.strategy.ProvidedInValueStrategy",
+        "writemodel.strategy": "com.mongodb.kafka.connect.sink.writemodel.strategy.ReplaceOneDefaultStrategy",
+        "transforms": "dropTombstones",
+        "transforms.dropTombstones.type": "org.apache.kafka.connect.transforms.Filter",
+        "transforms.dropTombstones.predicate": "isTombstone",
+        "predicates": "isTombstone",
+        "predicates.isTombstone.type": "org.apache.kafka.connect.transforms.predicates.RecordIsTombstone"
+    }
+}

--- a/hack/source-debezium/mongodb-source.json
+++ b/hack/source-debezium/mongodb-source.json
@@ -1,0 +1,21 @@
+{
+    "name": "source_cdc_mongodb_demo",
+    "config": {
+        "connector.class": "io.debezium.connector.mongodb.MongoDbConnector",
+        "tasks.max": "1",
+        "mongodb.connection.string": "mongodb://dbrep-mongodb-0.dbrep-mongodb-headless.dev.svc.cluster.local:27017/?replicaSet=rs0&directConnection=true",
+        "topic.prefix": "cdc_mongodb",
+        "database.include.list": "source_database",
+        "collection.include.list": "source_database.source_orders",
+        "capture.mode": "change_streams_update_full",
+        "snapshot.mode": "initial",
+        "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "key.converter.schemas.enable": "false",
+        "value.converter.schemas.enable": "false",
+        "transforms": "unwrap",
+        "transforms.unwrap.type": "io.debezium.connector.mongodb.transforms.ExtractNewDocumentState",
+        "transforms.unwrap.delete.handling.mode": "drop",
+        "transforms.unwrap.drop.tombstones": "true"
+    }
+}


### PR DESCRIPTION
- Add MongoDB single-node replica set deployment
- Add Debezium MongoDbConnector source and MongoDB Kafka sink configs
- Add Makefile.mongo-e2e with full E2E pipeline (setup, register, test, verify, clean)
- Wire mongo-e2e targets into root Makefile
- Fix MongoDB pod readiness label in Makefile.common
- Fix verify display to use EJSON.stringify instead of JSON.stringify