### PR TITLE
fix: point connect-distributed at log4j2 config for cp-kafka-connect 8.x

### DIFF
--- a/deployment/kafka-connect/docker/connect-distributed
+++ b/deployment/kafka-connect/docker/connect-distributed
@@ -42,14 +42,14 @@ for library in "kafka" "confluent-common" "kafka-serde-tools" "monitoring-interc
 done
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
-  LOG4J_CONFIG_NORMAL_INSTALL="/etc/kafka/connect-log4j.properties"
-  LOG4J_CONFIG_ZIP_INSTALL="$base_dir/../etc/kafka/connect-log4j.properties"
+  LOG4J_CONFIG_NORMAL_INSTALL="/etc/kafka/connect-log4j2.yaml"
+  LOG4J_CONFIG_ZIP_INSTALL="$base_dir/../etc/kafka/connect-log4j2.yaml"
   if [ -e "$LOG4J_CONFIG_NORMAL_INSTALL" ]; then # Normal install layout
-    KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:${LOG4J_CONFIG_NORMAL_INSTALL}"
+    KAFKA_LOG4J_OPTS="-Dlog4j2.configurationFile=${LOG4J_CONFIG_NORMAL_INSTALL}"
   elif [ -e "${LOG4J_CONFIG_ZIP_INSTALL}" ]; then # Simple zip file layout
-    KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:${LOG4J_CONFIG_ZIP_INSTALL}"
+    KAFKA_LOG4J_OPTS="-Dlog4j2.configurationFile=${LOG4J_CONFIG_ZIP_INSTALL}"
   else # Fallback to normal default
-    KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/connect-log4j.properties"
+    KAFKA_LOG4J_OPTS="-Dlog4j2.configurationFile=$base_dir/../config/connect-log4j2.yaml"
   fi
 fi
 export KAFKA_LOG4J_OPTS


### PR DESCRIPTION
The 7.8.0-era script still looked for connect-log4j.properties and used the log4j1 -Dlog4j.configuration flag. The 8.3.0 base image ships connect-log4j2.yaml instead, so the stale path caused a Reconfiguration failure and silently dropped back to Log4j2 defaults.